### PR TITLE
APPS-379 Posthoc plot: Filter adj-p & multi-select interaction

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: PollyCommonR
 Type: Package
 Title: Polly Common Functions in R
-Version: 0.6.7
+Version: 0.6.8
 Author: Sunil Dhakad
 Maintainer: The package maintainer <sunil.dhakad@elucidata.io>
 Description: This package contains common functions that are used in omics analysis.

--- a/man/create_pairwise_posthoc_boxplot.Rd
+++ b/man/create_pairwise_posthoc_boxplot.Rd
@@ -8,7 +8,8 @@ create_pairwise_posthoc_boxplot(
   posthoc_data_long_df = NULL,
   intensity_data = NULL,
   selected_metabolite = NULL,
-  selected_interaction = NULL
+  selected_interaction = NULL,
+  filter_pvalues = FALSE
 )
 }
 \arguments{


### PR DESCRIPTION
**1. Filter by p-value adjustment:** Added a checkbox that allows users to exclude rows with adjusted p-values greater than equal to 0.05 from the displayed results.
**2. Multiple interaction selection:** Updated the interaction dropdown menu to allow users to select multiple interaction terms simultaneously.

image.png