### PR TITLE
APPS-383 Axis label text overlap in post-hoc plots fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: PollyCommonR
 Type: Package
 Title: Polly Common Functions in R
-Version: 0.7.0
+Version: 0.7.1
 Author: Sunil Dhakad
 Maintainer: The package maintainer <sunil.dhakad@elucidata.io>
 Description: This package contains common functions that are used in omics analysis.

--- a/man/create_pairwise_posthoc_boxplot.Rd
+++ b/man/create_pairwise_posthoc_boxplot.Rd
@@ -9,7 +9,8 @@ create_pairwise_posthoc_boxplot(
   intensity_data = NULL,
   selected_metabolite = NULL,
   selected_interaction = NULL,
-  filter_pvalues = FALSE
+  filter_pvalues = FALSE,
+  plot_axis_rotation = FALSE
 )
 }
 \arguments{
@@ -20,9 +21,13 @@ create_pairwise_posthoc_boxplot(
 \item{selected_metabolite}{The selected metabolite for analysis.}
 
 \item{selected_interaction}{The selected interaction for analysis.}
+
+\item{filter_pvalues}{Logical indicating whether to filter comparisons with adj. p-value >= 0.05.}
+
+\item{plot_axis_rotation}{Logical indicating whether to rotate axis labels and wrap text.}
 }
 \value{
-A plotly object representing the pairwise post-hoc boxplot.
+A ggplot2 object representing the pairwise post-hoc boxplot.
 }
 \description{
 Creates a pairwise post-hoc boxplot for selected metabolite and interaction.


### PR DESCRIPTION
Addressed cohort names overlap by implementing text wrapping and vertical rotation (45 degrees) for axis labels in post-hoc plots for improved readability.

![image](https://github.com/ElucidataInc/PollyCommonR/assets/125878873/600a0e3a-92f9-4bd5-a306-6a9b0a91fbc1)
