### PR TITLE
APPS-387 Display Significance Numbers for All Columns in ANOVA Plot Fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: PollyCommonR
 Type: Package
 Title: Polly Common Functions in R
-Version: 0.7.2
+Version: 0.7.3
 Author: Sunil Dhakad
 Maintainer: The package maintainer <sunil.dhakad@elucidata.io>
 Description: This package contains common functions that are used in omics analysis.


### PR DESCRIPTION
Display Significance Numbers for All categorical Columns in ANOVA Plot
**Solution:** Users will now be able to see and interpret significance numbers for every categorical column in the ANOVA plot. Old code was based on just 2 categories: Significant and Non-significant.

<img width="1305" alt="image" src="https://github.com/user-attachments/assets/4eeaf668-1ce4-46f7-9295-dd1b5101a9c0">
