### PR TITLE
APPS-393 Display Significance Numbers for All Cols in Volcano Plot Fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: PollyCommonR
 Type: Package
 Title: Polly Common Functions in R
-Version: 0.7.3
+Version: 0.7.4
 Author: Sunil Dhakad
 Maintainer: The package maintainer <sunil.dhakad@elucidata.io>
 Description: This package contains common functions that are used in omics analysis.

--- a/R/plot_anova.R
+++ b/R/plot_anova.R
@@ -271,7 +271,8 @@ plot_anova <- function(anova_data = NULL, p_val_cutoff = 0.05, interaction_type 
     print(significance_table)
     
     anova_data$threshold_with_count <- sapply(anova_data$threshold, function(x) {
-      paste(x, significance_table[x], sep = ": ")
+      count <- significance_table[as.character(x)]
+      paste0(x, " (", count, ")")
     })
   }
   
@@ -405,11 +406,7 @@ plot_anova <- function(anova_data = NULL, p_val_cutoff = 0.05, interaction_type 
         yaxis = list(title = y_label),
         xaxis = list(title = x_label),
         annotations = a,
-        showlegend = TRUE,
-        legend = list(
-          title = list(text = "Significance"),
-          traceorder = "normal"
-        )
+        showlegend = TRUE
       ) %>%
       add_annotations(text="Significance", xref="paper", yref="paper",
                       x=1.04, xanchor="left",


### PR DESCRIPTION
Display Significance Numbers for All categorical Columns in Volcano Plot
Solution: Users will now be able to see and interpret significance numbers for every categorical column in the Volcano plot. Old code was based on just 2 categories: Significant and Non-significant.

<img width="1296" alt="image" src="https://github.com/user-attachments/assets/053f153a-83b1-45a9-927f-8abd25dae47b">
